### PR TITLE
Added null | undefined to ClassNameFragment

### DIFF
--- a/src/classnamer.ts
+++ b/src/classnamer.ts
@@ -1,6 +1,6 @@
 export type ClassNamePrimitive = string | number | boolean;
 export type ClassNameObject = { [key: string]: boolean };
-export type ClassNameFragment = ClassNamePrimitive | ClassNameObject | ClassNameFragmentList;
+export type ClassNameFragment = ClassNamePrimitive | ClassNameObject | ClassNameFragmentList | null | undefined;
 export interface ClassNameFragmentList extends Array<ClassNameFragment> { }
 
 export default function classnamer(...args: ClassNameFragment[]) {

--- a/src/classnamer.ts
+++ b/src/classnamer.ts
@@ -1,17 +1,16 @@
 export type ClassNamePrimitive = string | number | boolean;
-export type ClassNameObject = { [key: string]: boolean };
+export type ClassNameObject = { [key: string]: boolean | null | undefined };
 export type ClassNameFragment = ClassNamePrimitive | ClassNameObject | ClassNameFragmentList | null | undefined;
 export interface ClassNameFragmentList extends Array<ClassNameFragment> { }
 
 export default function classnamer(...args: ClassNameFragment[]) {
     let accum = "";
-    for (let i = 0; i < arguments.length; i++) {
-        let arg = arguments[i];
+    for (let i = 0; i < args.length; i++) {
+        let arg = args[i];
         if (!arg) {
             continue;
         }
-        let argType = typeof arg;
-        if (argType === "string" || argType === "number" || argType === "boolean") {
+        if (typeof arg === "string" || typeof arg === "number" || typeof arg === "boolean") {
             accum += " " + arg;
         } else if (Array.isArray(arg)) {
             accum += " " + classnamer.apply(null, arg);

--- a/src/classnamer.ts
+++ b/src/classnamer.ts
@@ -1,4 +1,4 @@
-export type ClassNamePrimitive = string | number | boolean;
+export type ClassNamePrimitive = string | number | boolean | null | undefined;
 export type ClassNameObject = { [key: string]: boolean | null | undefined };
 export type ClassNameFragment = ClassNamePrimitive | ClassNameObject | ClassNameFragmentList | null | undefined;
 export interface ClassNameFragmentList extends Array<ClassNameFragment> { }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,6 +11,7 @@
         "noLib": false,
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true,
+        "strictNullChecks": true,
         "outDir": "../dist"
     },
     "filesGlob": [


### PR DESCRIPTION
Added null | undefined to ClassNameFragment because null | undefined class names are allowed and simply stepped over. Adding this type permits easier use in strictNullChecks